### PR TITLE
Added functions to link to the News API servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Coming soon... this is where our officially supported SDK for PHP is going to li
 ```php
 <?php
 include 'vendor/autoload.php';
-$newsapi = NewsAPI\NewsAPI('your_api_key_here');
+$newsapi = new NewsAPI\NewsAPI('your_api_key_here');
 $request = $newsapi->category('technology')->language('en')->getTopHeadlines();
+// Returns a PHP Object parsed through the JSON response.
+var_dump($request);
 ```
 
 ***

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # News API SDK for PHP
 Coming soon... this is where our officially supported SDK for PHP is going to live.
 
+## Example
+```php
+<?php
+include 'vendor/autoload.php';
+$newsapi = NewsAPI\NewsAPI('your_api_key_here');
+$request = $newsapi->category('technology')->language('en')->getTopHeadlines();
+```
+
 ***
 
 ## Developers... we need you!

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "news-api/news-api",
+    "type": "library",
+    "license": "MIT",
+    "require": {}
+}

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,8 @@
     "name": "news-api/news-api",
     "type": "library",
     "license": "MIT",
-    "require": {}
+    "require": {},
+    "psr-4": {
+        "NewsAPI\\NewsAPI\\": "src/" 
+    }
 }

--- a/src.php
+++ b/src.php
@@ -3,7 +3,7 @@
 namespace NewsAPI;
 
 class NewsAPI {
-    protected $APIKey, $category, $language, $country;
+    protected $APIKey, $category, $language, $country, $q, $sources, $domains, $from, $to, $sortBy, $page;
     public function __construct($APIKey = null) {
         $this->APIKey = $APIKey;
     }
@@ -23,7 +23,70 @@ class NewsAPI {
         $this->country = $country;
         return $this;
     }
-    public function sources($arr = null) {
+    public function q($q) {
+        $this->q = $q;
+        return $this;
+    }
+    public function sources($sources) {
+        $this->sources = $sources;
+        return $this;
+    }
+    public function domains($domains) {
+        $this->domains = $domains;
+        return $this;
+    }
+    public function from($from) {
+        $this->from = $from;
+        return $this;
+    }
+    public function to($to) {
+        $this->to = $to;
+        return $this;
+    }
+    public function sortBy($sortBy) {
+        $this->sortBy = $sortBy;
+        return $this;
+    }
+    public function page($page) {
+        $this->page = $page;
+        return $this;
+    }
+    public function getTopHeadlines($arr = null) {
+        if ($arr != null) {
+            $body = $arr;
+        }
+        else {
+            $body = [
+                'q' => $this->q,
+                'sources' => $this->sources,
+                'category' => $this->category,
+                'language' => $this->language,
+                'country' => $this->country
+            ];
+        }
+        $url = 'https://newsapi.org/v2/top-headlines' . "?" . http_build_query($body);
+        return $this->sendRequest($url);
+    }
+    public function getEverything($arr = null) {
+        if ($arr != null) {
+            $body = $arr;
+        }
+        else {
+            $body = [
+                'q' => $this->q,
+                'sources' => $this->sources,
+                'domains' => $this->domains,
+                'from' => $this->from,
+                'to' => $this->to,
+                'language' => $this->language,
+                'sortBy' => $this->sortBy,
+                'page' => $this->page,
+            ];
+        }
+        $url = 'https://newsapi.org/v2/everything' . "?" . http_build_query($body);
+        return $this->sendRequest($url);
+    }
+    public function getSources($arr = null) {
         if ($arr != null) {
             $body = $arr;
         }

--- a/src.php
+++ b/src.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace NewsAPI;
+
+class NewsAPI {
+    protected $APIKey, $category, $language, $country;
+    private $cu;
+    public function __construct($APIKey = null) {
+        $this->APIKey = $APIKey;
+    }
+    public function setAPIKey($APIKey) {
+        $this->APIKey = $APIKey;
+    }
+    public function category($category) {
+        $this->category = $category;
+        return $this;
+    }
+    public function language($language) {
+        $this->language = $language;
+        return $this;
+    }
+    public function country($country) {
+        $this->country = $country;
+        return $this;
+    }
+    public function sources() {
+        $this->cu = curl_init();
+        $curlArgs = [
+            CURLOPT_URL => 'https://newsapi.org/v2/sources',
+            CURLOPT_HTTPHEADER => array(
+                "Authorization: ".$this->APIKey
+            ),
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_SSL_VERIFYPEER => 0,
+            CURLOPT_SSL_VERIFYHOST => 0
+        ];
+        curl_setopt_array($this->cu, $curlArgs);
+        return curl_exec($this->cu);
+    }
+}
+
+?>

--- a/src.php
+++ b/src.php
@@ -4,12 +4,12 @@ namespace NewsAPI;
 
 class NewsAPI {
     protected $APIKey, $category, $language, $country;
-    private $cu;
     public function __construct($APIKey = null) {
         $this->APIKey = $APIKey;
     }
     public function setAPIKey($APIKey) {
         $this->APIKey = $APIKey;
+        return $this;
     }
     public function category($category) {
         $this->category = $category;
@@ -23,20 +23,34 @@ class NewsAPI {
         $this->country = $country;
         return $this;
     }
-    public function sources() {
-        $this->cu = curl_init();
+    public function sources($arr = null) {
+        if ($arr != null) {
+            $body = $arr;
+        }
+        else {
+            $body = [
+                'country' => $this->country,
+                'language' => $this->language,
+                'category' => $this->category
+            ];
+        }
+        $url = 'https://newsapi.org/v2/sources' . "?" . http_build_query($body);
+        return $this->sendRequest($url);
+    }
+    private function sendRequest($url) {
+        $cu = curl_init();
         $curlArgs = [
-            CURLOPT_URL => 'https://newsapi.org/v2/sources',
-            CURLOPT_HTTPHEADER => array(
+            CURLOPT_URL => $url,
+            CURLOPT_HTTPHEADER => [
                 "Authorization: ".$this->APIKey
-            ),
+            ],
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_CONNECTTIMEOUT => 10,
             CURLOPT_SSL_VERIFYPEER => 0,
             CURLOPT_SSL_VERIFYHOST => 0
         ];
-        curl_setopt_array($this->cu, $curlArgs);
-        return curl_exec($this->cu);
+        curl_setopt_array($cu, $curlArgs);
+        return curl_exec($cu);
     }
 }
 

--- a/src/src.php
+++ b/src/src.php
@@ -113,7 +113,7 @@ class NewsAPI {
             CURLOPT_SSL_VERIFYHOST => 0
         ];
         curl_setopt_array($cu, $curlArgs);
-        return curl_exec($cu);
+        return json_decode(curl_exec($cu));
     }
 }
 


### PR DESCRIPTION
 The library offers three main functions to get the data. These are `getSources`, `getTopHeadlines`, and `getEverything`. Users may either use method chaining or placing an array into the respective functions in order to send data to the requests.

## Example:
These two examples return the same data. They're just different available methods in placing the data.
```php
<?php
include 'vendor/autoload.php';
$newsapi = new NewsAPI\NewsAPI('your_api_key_here');
$request = $newsapi->category('technology')->language('en')->getTopHeadlines();
var_dump($request);
```

```php
<?php
include 'vendor/autoload.php';
$newsapi = new NewsAPI\NewsAPI('your_api_key_here');
$request = $newsapi->getTopHeadlines([
'category' => 'technology',
'language' => 'en'
]);
var_dump($request);
```